### PR TITLE
Improve children instances order

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ class App extends Stack {
   static attrName = "App"
 
   // list of page components
-  pages() {
+  addPages() {
     return {
       HomePage,
       AboutPage,

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ class App extends Component {
   }
 
   // Create new instance for children component list
-  components = {
+  addComponents = () => ({
     Header: this.add(Header),
-  }
+  })
 
   // target child BEM DOM elements
   elements = {
@@ -102,21 +102,21 @@ class Header extends Component {
 ### `beforeMount()`
 
 Method called before class component is mounted.
-Current class instance is already available.
+Current class instance is already available but children component instances are not yet.
 
 ### `mounted()`
 
-Method called after class component is mounted.
+Method called after class component is mounted. Children component instances are now available.
 
 ### `unmounted()`
 
 Method called after class component is unmounted.
-The parent component observer will called this unmounted method automatically  
-if the current component is removed from DOM.
+The parent component observer will called this unmounted method automatically if the current component is removed from DOM.
+All children component instances are also unmounted after this method is called.
 
 ### `updated()`
 
-Method called when any children component in DOM subtree changed.
+Method called when any **children** component in DOM subtree changed.
 
 ## Methods & Properties
 
@@ -153,13 +153,23 @@ add<T = Component, P = TProps>(
 ): T;
 ```
 
+To "add" all children components, use `addComponents()` method.
+
 ```js
-components = {
-  Bar: this.add(Bar),
+addComponents() {
+  return {
+    Bar: this.add(Bar),
+  }
 }
+
+// or the short version with arrow function not assigned to the prototype
+addComponents = () => ({
+    Bar: this.add(Bar),
+})
+
 // then, access child Bar instance
-this.Bar.$root
-this.Bar.unmounted()
+this.components.Bar.$root
+this.components.Bar.unmounted()
 // ...
 ```
 
@@ -176,34 +186,34 @@ In case, multi children of the same component is found, `add()` will returned an
 ```
 
 ```js
-components = {
+addComponents = () => ({
   Bar: this.add(Bar), // will returned array of Bar instances
-}
+})
 ```
 
 If we don't know how many instance of our component `Bar` exist,
 it's possible to force `add()` to return an array via `returnArray` parameter.
 
 ```js
-components = {
+addComponents = () => ({
   Bar: this.add(Bar, {}, true),
-}
+})
 ```
 
 With typescript, we can explicitly state that we are expecting an array.
 
 ```ts
-components = {
+addComponents = () => ({
   Bar: this.add<Bar[]>(Bar),
-}
+})
 ```
 
 The method accepts a static props parameter which we can access from the new Bar component via `this.props`.
 
 ```js
-components = {
+addComponents = () => ({
   Bar: this.add(Bar, { myProp: "foo" }),
-}
+})
 ```
 
 With typescript, we can type the `props` object:

--- a/example/index.html
+++ b/example/index.html
@@ -25,6 +25,12 @@
                 I'm a button
               </button>
             </header>
+            <button class="MainButton MainButton-2" data-component="MainButton">
+              I'm a button
+            </button>
+            <button class="MainButton MainButton-3" data-component="MainButton">
+              I'm a button
+            </button>
           </div>
         </div>
       </main>

--- a/example/src/components/App.ts
+++ b/example/src/components/App.ts
@@ -5,34 +5,33 @@ import WorkPage from "../pages/WorkPage"
 import debug from "@wbe/debug"
 const log = debug(`front:App`)
 
+type TProps = {
+  foo: string
+}
+
 /**
  * @name App
  */
-export default class App extends Stack {
+export default class App extends Stack<TProps> {
   public static attrName = "App"
 
-  // disableLinksDuringTransitions = true
-  // disableHistoryDuringTransitions = true
-  forcePageReloadIfDocumentIsFetching = true
-
-  constructor($root, props) {
-    log(`constructor`)
+  constructor($root, props: TProps) {
     super($root, props)
+  }
+
+  public addPages() {
+    return {
+      HomePage,
+      AboutPage,
+      WorkPage,
+    }
   }
 
   /**
    * mounted
    */
   public mounted() {
-    log('mounted')
-  }
-
-  protected pages() {
-    return {
-      HomePage,
-      AboutPage,
-      WorkPage,
-    }
+    
   }
 
   protected async pageTransitions(
@@ -45,4 +44,8 @@ export default class App extends Stack {
     await newPage.playIn()
     complete()
   }
+
+  // disableLinksDuringTransitions = true
+  // disableHistoryDuringTransitions = true
+  forcePageReloadIfDocumentIsFetching = true
 }

--- a/example/src/components/App.ts
+++ b/example/src/components/App.ts
@@ -16,8 +16,15 @@ export default class App extends Stack {
   forcePageReloadIfDocumentIsFetching = true
 
   constructor($root, props) {
-
+    log(`constructor`)
     super($root, props)
+  }
+
+  /**
+   * mounted
+   */
+  public mounted() {
+    log('mounted')
   }
 
   protected pages() {

--- a/example/src/components/Header.ts
+++ b/example/src/components/Header.ts
@@ -14,11 +14,13 @@ export default class Header extends Component {
     super($root, props);
     this.init();
   }
-
-  public components = {
-    MainButton: this.add(MainButton)
+  
+  public addComponents() {
+    return {
+      MainButton: this.add(MainButton)          
+    }
   }
-
+  
   public mounted() {
     window.addEventListener("resize", this.resizeHandler);
   }

--- a/example/src/components/Header.ts
+++ b/example/src/components/Header.ts
@@ -4,10 +4,16 @@ import MainButton from "./MainButton"
 import debug from "@wbe/debug"
 const log = debug(`front:Header`)
 
+type TStaticProps = {}
+
+type TAddComponents = {
+  MainButton: InstanceType<typeof MainButton>
+}
+
 /**
  * @name Header
  */
-export default class Header extends Component {
+export default class Header extends Component<TStaticProps, TAddComponents> {
   public static attrName = "Header";
 
   constructor($root, props) {

--- a/example/src/helpers/defaultTransitions.ts
+++ b/example/src/helpers/defaultTransitions.ts
@@ -7,7 +7,7 @@ const xValue = 100
 const duration = 1
 
 export const defaultPlayIn = ($root?: HTMLElement, comeFrom?: string, resolve?: () => void): void => {
-  log("comeFrom:", comeFrom)
+  // log("comeFrom:", comeFrom)
   gsap.fromTo(
     $root,
     {
@@ -25,7 +25,7 @@ export const defaultPlayIn = ($root?: HTMLElement, comeFrom?: string, resolve?: 
 }
 
 export const defaultPlayOut = ($root?: HTMLElement, goTo?: string, resolve?: () => void): void => {
-  log("goTo: ", goTo)
+  // log("goTo: ", goTo)
   gsap.fromTo(
     $root,
     {

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,4 +1,4 @@
 import "./index.css";
 import App from "./components/App"
 
-new App(document.querySelector(".App"), {});
+new App(document.querySelector(".App"), { foo: "bar" });

--- a/example/src/pages/AboutPage.ts
+++ b/example/src/pages/AboutPage.ts
@@ -4,10 +4,17 @@ import { defaultPlayIn, defaultPlayOut } from "../helpers/defaultTransitions"
 import debug from "@wbe/debug"
 const log = debug(`front:AboutPage`)
 
+
+type TStaticProps = {}
+
+type TAddComponents = {
+  Header: InstanceType<typeof Header>
+}
+
 /**
  * @name AboutPage
  */
-export default class AboutPage extends Component {
+export default class AboutPage extends Component<TStaticProps, TAddComponents> {
   public static attrName = "AboutPage"
 
   constructor($root, props) {

--- a/example/src/pages/AboutPage.ts
+++ b/example/src/pages/AboutPage.ts
@@ -15,10 +15,11 @@ export default class AboutPage extends Component {
     this.init()
   }
 
-  public components = {
-    Header: this.add(Header),
+  public addComponents() {
+    return {
+      Header: this.add(Header),
+    }
   }
-
   public mounted() {
     window.addEventListener("resize", this.resizeHandler)
   }

--- a/example/src/pages/HomePage.ts
+++ b/example/src/pages/HomePage.ts
@@ -1,7 +1,6 @@
 import { Component } from "../../../src"
-import debugModule from "debug"
 import Header from "../components/Header"
-import { defaultPlayIn, defaultPlayOut } from "../helpers/defaultTransitions"
+import {  defaultPlayIn,  defaultPlayOut } from "../helpers/defaultTransitions"
 import debug from "@wbe/debug"
 const log = debug(`front:HomePage`)
 
@@ -16,11 +15,12 @@ export default class HomePage extends Component {
     this.init()
   }
 
-  public components = {
+  public addComponents = () => ({
     Header: this.add(Header),
-  }
+  })
 
   public mounted() {
+    log('this.components',this.components)
     window.addEventListener("resize", this.resizeHandler)
   }
 

--- a/example/src/pages/HomePage.ts
+++ b/example/src/pages/HomePage.ts
@@ -23,12 +23,10 @@ export default class HomePage extends Component<TStaticProps, TAddComponents> {
     this.init()
   }
 
-  addComponents() {
-    return {
+  public addComponents = () => ({
       Header: this.add(Header),
       MainButton: this.add<MainButton[]>(MainButton),
-    }
-  }
+  })
 
   public mounted() {
     log("this.components", this.components)

--- a/example/src/pages/HomePage.ts
+++ b/example/src/pages/HomePage.ts
@@ -1,13 +1,21 @@
 import { Component } from "../../../src"
 import Header from "../components/Header"
-import {  defaultPlayIn,  defaultPlayOut } from "../helpers/defaultTransitions"
+import { defaultPlayIn, defaultPlayOut } from "../helpers/defaultTransitions"
 import debug from "@wbe/debug"
+import MainButton from "../components/MainButton"
 const log = debug(`front:HomePage`)
+
+type TStaticProps = {}
+
+type TAddComponents = {
+  Header: InstanceType<typeof Header>
+  MainButton: InstanceType<typeof MainButton>[]
+}
 
 /**
  * @name HomePage
  */
-export default class HomePage extends Component {
+export default class HomePage extends Component<TStaticProps, TAddComponents> {
   public static attrName = "HomePage"
 
   constructor($root, props) {
@@ -15,12 +23,15 @@ export default class HomePage extends Component {
     this.init()
   }
 
-  public addComponents = () => ({
-    Header: this.add(Header),
-  })
+  addComponents() {
+    return {
+      Header: this.add(Header),
+      MainButton: this.add<MainButton[]>(MainButton),
+    }
+  }
 
   public mounted() {
-    log('this.components',this.components)
+    log("this.components", this.components)
     window.addEventListener("resize", this.resizeHandler)
   }
 

--- a/example/src/pages/WorkPage.ts
+++ b/example/src/pages/WorkPage.ts
@@ -4,10 +4,16 @@ import { defaultPlayIn, defaultPlayOut } from "../helpers/defaultTransitions"
 import debug from "@wbe/debug"
 const log = debug(`front:WorkPage`)
 
+type TStaticProps = {}
+
+type TAddComponents = {
+  Header: InstanceType<typeof Header>
+}
+
 /**
  * @name WorkPage
  */
-export default class WorkPage extends Component {
+export default class WorkPage extends Component<TStaticProps, TAddComponents> {
   public static attrName = "WorkPage"
 
   constructor($root, props) {

--- a/example/src/pages/WorkPage.ts
+++ b/example/src/pages/WorkPage.ts
@@ -1,5 +1,4 @@
 import { Component } from "../../../src"
-import debugModule from "debug"
 import Header from "../components/Header"
 import { defaultPlayIn, defaultPlayOut } from "../helpers/defaultTransitions"
 import debug from "@wbe/debug"
@@ -15,12 +14,15 @@ export default class WorkPage extends Component {
     super($root, props)
     this.init()
   }
-
-  public components = {
-    Header: this.add(Header),
+  
+  public addComponents() {
+    return {
+      Header: this.add(Header),
+    }
   }
 
   public mounted() {
+    log("use this.components", this.components)
     window.addEventListener("resize", this.resizeHandler)
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wbe/compose",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wbe/compose",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@wbe/debug": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wbe/compose",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Compose is a tiny zero dependency library for vanilla javascript component approach and page transitions management.",
   "author": "Willy Brauner",
   "license": "MIT",

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -1,4 +1,6 @@
 import { TPromiseRef } from "./Stack"
+import debug from "@wbe/debug"
+const log = debug(`compose:Component`)
 
 type TFlatArray<T> = T extends any[] ? T[number] : T
 
@@ -33,6 +35,9 @@ export class Component<Props = TProps> {
   public $root: HTMLElement
   public props: Props
   public components: TComponents
+  public addComponents(): TComponents {
+    return {}
+  }
   public elements: TElements
   public id: number
   public isMounted: boolean
@@ -78,8 +83,11 @@ export class Component<Props = TProps> {
    */
   public mounted(): void {}
   private _mounted(): void {
-    this.isMounted = true
+    log(this.name, "mounted")
+    // instanciate children components just before mounted
+    this.components = this.addComponents()
     this.mounted()
+    this.isMounted = true
   }
 
   /**
@@ -88,12 +96,12 @@ export class Component<Props = TProps> {
    */
   public unmounted() {}
   private _unmounted(): void {
-    this.isMounted = false
     this.unmounted()
     this.onChildrenComponents((component: Component) => {
       COMPONENT_ID--
       component?._unmounted?.()
     })
+    this.isMounted = false
   }
 
   /**

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -8,8 +8,8 @@ export type TNewComponent<C, P> = new <P = TProps>(...rest: any[]) => TFlatArray
 
 export type TProps = { [x: string]: any } | void
 
-export type TComponents = {
-  [name: string]: any | any[]
+export type TComponents<T = any> = {
+  [name: string]: T | T[]
 }
 
 export type TElements = {
@@ -34,10 +34,7 @@ export class Component<Props = TProps> {
   public name: string
   public $root: HTMLElement
   public props: Props
-  public components: TComponents
-  public addComponents(): TComponents {
-    return {}
-  }
+  
   public elements: TElements
   public id: number
   public isMounted: boolean
@@ -60,6 +57,13 @@ export class Component<Props = TProps> {
     this.id = COMPONENT_ID
     COMPONENT_ID++
   }
+
+  // register children components
+  public addComponents(): TComponents {
+    return {}
+  }
+  public components: TComponents
+  
 
   /**
    * Init to call in contructor (to keep context)
@@ -97,11 +101,11 @@ export class Component<Props = TProps> {
   public unmounted() {}
   private _unmounted(): void {
     this.unmounted()
+    this.isMounted = false
     this.onChildrenComponents((component: Component) => {
       COMPONENT_ID--
       component?._unmounted?.()
     })
-    this.isMounted = false
   }
 
   /**

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -20,7 +20,7 @@ let COMPONENT_ID = 0
 /**
  * Component
  */
-export class Component<Props = TProps, TAddComponents = {}> {
+export class Component<Props = TProps, TAddComponents = any> {
   public name: string
   public $root: HTMLElement
   public props: Props

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -1,15 +1,10 @@
-import { TPromiseRef } from "./Stack"
+import type { TPromiseRef } from "./Stack"
 import debug from "@wbe/debug"
 const log = debug(`compose:Component`)
-
 
 export type TProps = { [x: string]: any } | void
 export type TFlatArray<T> = T extends any[] ? T[number] : T
 export type TNewComponent<C, P> = new <P = TProps>(...rest: any[]) => TFlatArray<C>
-
-// export type TComponents<T = any> = {
-//   [name: string]: T | T[]
-// }
 
 export type TElements = {
   [x: string]: HTMLElement | HTMLElement[]
@@ -33,7 +28,7 @@ export class Component<Props = TProps, TChildren = any> {
   public name: string
   public $root: HTMLElement
   public props: Props
-  
+
   public elements: TElements
   public id: number
   public isMounted: boolean
@@ -58,9 +53,11 @@ export class Component<Props = TProps, TChildren = any> {
   }
 
   // register children components
-  public addComponents (): TChildren  { return {} as TChildren };
+  public addComponents(): TChildren {
+    return {} as TChildren
+  }
   public components: TChildren
- 
+
   /**
    * Init to call in contructor (to keep context)
    */
@@ -145,15 +142,6 @@ export class Component<Props = TProps, TChildren = any> {
     // return single instance or instances array
     return localInstances.length === 1 && !returnArray ? localInstances[0] : localInstances
   }
-
-  // protected addAll<T = any, P = TProps>(
-  //   classComponent: TNewComponent<T, P>,
-  //   props?: P,
-  //   attrName?: string,
-  //   returnArray: boolean = false
-  // ): T[] {
-  //   return this.add()
-  // }
 
   /**
    * Find HTML element with BEM element name

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -5,11 +5,7 @@ const log = debug(`compose:Component`)
 export type TProps = { [x: string]: any } | void
 export type TFlatArray<T> = T extends any[] ? T[number] : T
 export type TNewComponent<C, P> = new <P = TProps>(...rest: any[]) => TFlatArray<C>
-
-export type TElements = {
-  [x: string]: HTMLElement | HTMLElement[]
-}
-
+export type TElements = {  [x: string]: HTMLElement | HTMLElement[] }
 export type TTransition = {
   comeFrom?: string
   goTo?: string
@@ -24,10 +20,14 @@ let COMPONENT_ID = 0
 /**
  * Component
  */
-export class Component<Props = TProps, TChildren = any> {
+export class Component<Props = TProps, TAddComponents = {}> {
   public name: string
   public $root: HTMLElement
   public props: Props
+
+  // register children components
+  public addComponents(): TAddComponents { return {} as TAddComponents } 
+  public components: TAddComponents
 
   public elements: TElements
   public id: number
@@ -51,12 +51,6 @@ export class Component<Props = TProps, TChildren = any> {
     this.id = COMPONENT_ID
     COMPONENT_ID++
   }
-
-  // register children components
-  public addComponents(): TChildren {
-    return {} as TChildren
-  }
-  public components: TChildren
 
   /**
    * Init to call in contructor (to keep context)

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -2,15 +2,14 @@ import { TPromiseRef } from "./Stack"
 import debug from "@wbe/debug"
 const log = debug(`compose:Component`)
 
-type TFlatArray<T> = T extends any[] ? T[number] : T
-
-export type TNewComponent<C, P> = new <P = TProps>(...rest: any[]) => TFlatArray<C>
 
 export type TProps = { [x: string]: any } | void
+export type TFlatArray<T> = T extends any[] ? T[number] : T
+export type TNewComponent<C, P> = new <P = TProps>(...rest: any[]) => TFlatArray<C>
 
-export type TComponents<T = any> = {
-  [name: string]: T | T[]
-}
+// export type TComponents<T = any> = {
+//   [name: string]: T | T[]
+// }
 
 export type TElements = {
   [x: string]: HTMLElement | HTMLElement[]
@@ -30,7 +29,7 @@ let COMPONENT_ID = 0
 /**
  * Component
  */
-export class Component<Props = TProps> {
+export class Component<Props = TProps, TChildren = any> {
   public name: string
   public $root: HTMLElement
   public props: Props
@@ -59,12 +58,9 @@ export class Component<Props = TProps> {
   }
 
   // register children components
-  public addComponents(): TComponents {
-    return {}
-  }
-  public components: TComponents
-  
-
+  public addComponents (): TChildren  { return {} as TChildren };
+  public components: TChildren
+ 
   /**
    * Init to call in contructor (to keep context)
    */
@@ -149,6 +145,15 @@ export class Component<Props = TProps> {
     // return single instance or instances array
     return localInstances.length === 1 && !returnArray ? localInstances[0] : localInstances
   }
+
+  // protected addAll<T = any, P = TProps>(
+  //   classComponent: TNewComponent<T, P>,
+  //   props?: P,
+  //   attrName?: string,
+  //   returnArray: boolean = false
+  // ): T[] {
+  //   return this.add()
+  // }
 
   /**
    * Find HTML element with BEM element name

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { Stack } from "./Stack"
 export { Component } from "./Component"
 
-export type { IPage, TPageList } from "./Stack"
-export type { TTransition, TElements, TComponents, TNewComponent } from "./Component"
+export type { IPage, TPages } from "./Stack"
+export type { TTransition, TElements, TNewComponent } from "./Component"


### PR DESCRIPTION
# Instance order + types

The components order instance is inverted, the deepest in the tree was instanciated first : 
```
- AboutPage
  - Header (child of AboutPage)
    - MainButton (child of Header)
```

The console result: 
````
MainButton mounted
Header mounted
AboutPage mounted
````

We need to respect the tree order as below:

````
AboutPage mounted
Header mounted
MainButton mounted
````

To solve this, all children components need to be return from a method and executed just before the mounted() method.

# Stack pages() become `addPage()`

```js
  public addPages() {
    return {
      HomePage,
      AboutPage,
      WorkPage,
    }
  }
```
