### PR TITLE
v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,24 +35,7 @@ import Header from "Header"
 class App extends Component {
   // set the same value than `data-component` attribute value
   static attrName = "App"
-
-  // create new child instance 
-  header = this.add(Header)
-
-  // target child BEM DOM elements ("App_title")
-  $title = this.find("title")
-
-  // before class component is mounted
-  beforeMount() {}
-
-  // after class component is mounted
-  mounted() {}
-
-  // after class component is unmounted or the component $root is removed from DOM
-  unmounted() {}
-
-  // when children components are updated
-  updated() {}
+  
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ class Foo extends Component {
 This method allows to 'add', 'create' new Component instance to the tree.
 It returns instance(s) and associated properties.
 
-```
+```ts
 add<T = Component, P = TProps>(
     classComponent: TAddComponent,
     props?: P,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Compose is a tiny zero dependency library for vanilla javascript component appro
 
 ## Installation
 
-```shell script
+```shell
 $ npm install -s @wbe/compose
 ```
 
@@ -86,12 +86,6 @@ Method called after class component is mounted. Children component instances are
 Method called after class component is unmounted.
 The parent component observer will called this unmounted method automatically if the current component is removed from DOM.
 All children component instances are also unmounted after this method is called.
-
-### updated
-
-`updated()`
-
-Method called when any **children** component in DOM subtree changed.
 
 ## Methods & Properties
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ It returns instance(s) and associated properties.
 add<T = Component, P = TProps>(
     classComponent: TAddComponent,
     props?: P,
-    attrName?: string,
-    returnArray: boolean = false
+    returnArray?: boolean,
+    attrName?: string
 ): T;
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,21 +85,29 @@ class Header extends Component {
 
 ## Life cycle
 
-### `beforeMount()`
+### beforeMount
+
+`beforeMount()`
 
 Method called before class component is mounted, in at begining of class constructor.
 
-### `mounted()`
+### mounted
+
+`mounted()`
 
 Method called after class component is mounted. Children component instances are now available.
 
-### `unmounted()`
+### unmounted
+
+`unmounted()`
 
 Method called after class component is unmounted.
 The parent component observer will called this unmounted method automatically if the current component is removed from DOM.
 All children component instances are also unmounted after this method is called.
 
-### `updated()`
+### updated
+
+`updated()`
 
 Method called when any **children** component in DOM subtree changed.
 

--- a/README.md
+++ b/README.md
@@ -33,25 +33,14 @@ import { Component } from "@wbe/compose"
 import Header from "Header"
 
 class App extends Component {
-  // declare the name value of `data-component` attribute
+  // set the same value than `data-component` attribute value
   static attrName = "App"
 
-  // relay and init "Component" extended class methods
-  constructor($root, props) {
-    super($root, props)
-    this.init()
-  }
+  // create new child instance 
+  header = this.add(Header)
 
-  // Create new instance for children component list
-  addComponents = () => ({
-    Header: this.add(Header),
-  })
-
-  // target child BEM DOM elements
-  elements = {
-    // find DOM element with "App_title" class
-    $title: this.find("title"),
-  }
+  // target child BEM DOM elements ("App_title")
+  $title = this.find("title")
 
   // before class component is mounted
   beforeMount() {}
@@ -82,11 +71,6 @@ import { Component } from "@wbe/compose"
 class Header extends Component {
   static attrName = "Header"
 
-  constructor($root, props) {
-    super($root, props)
-    this.init()
-  }
-
   mounted() {
     window.addEventListener("resize", this.handleResize)
   }
@@ -103,8 +87,7 @@ class Header extends Component {
 
 ### `beforeMount()`
 
-Method called before class component is mounted.
-Current class instance is already available but children component instances are not yet.
+Method called before class component is mounted, in at begining of class constructor.
 
 ### `mounted()`
 
@@ -155,23 +138,14 @@ add<T = Component, P = TProps>(
 ): T;
 ```
 
-To "add" all children components, use `addComponents()` method.
+Add component in class core: 
 
 ```js
-addComponents() {
-  return {
-    Bar: this.add(Bar),
-  }
-}
-
-// or the short version with arrow function not assigned to the prototype
-addComponents = () => ({
-    Bar: this.add(Bar),
-})
+bar = this.add(Bar);
 
 // then, access child Bar instance
-this.components.Bar.$root
-this.components.Bar.unmounted()
+this.bar.$root
+this.bar.unmounted()
 // ...
 ```
 
@@ -188,42 +162,32 @@ In case, multi children of the same component is found, `add()` will returned an
 ```
 
 ```js
-addComponents = () => ({
-  Bar: this.add(Bar), // will returned array of Bar instances
-})
+bar = this.add(Bar); // will returned array of bar instances
 ```
 
 If we don't know how many instance of our component `Bar` exist,
 it's possible to force `add()` to return an array via `returnArray` parameter.
 
 ```js
-addComponents = () => ({
-  Bar: this.add(Bar, {}, true),
-})
+bar = this.add(Bar, {}, true)
 ```
 
 With typescript, we can explicitly state that we are expecting an array.
 
 ```ts
-addComponents = () => ({
-  Bar: this.add<Bar[]>(Bar),
-})
+bar = this.add<Bar[]>(Bar)
 ```
 
 The method accepts a static props parameter which we can access from the new Bar component via `this.props`.
 
 ```js
-addComponents = () => ({
-  Bar: this.add(Bar, { myProp: "foo" }),
-})
+bar = this.add(Bar, { myProp: "foo" })
 ```
 
 With typescript, we can type the `props` object:
 
 ```ts
-addComponents = () => ({
-  Bar: this.add<Bar, { myProp: string }>(Bar, { myProp: "foo" }, false),
-})
+bar = this.add<Bar, { myProp: string }>(Bar, { myProp: "foo" }, false)
 ```
 
 ### `components()`
@@ -236,29 +200,19 @@ When current component instance is unmounted, all instances returned by `compone
 This method allows to retrieve B.E.M. element of current $root component.
 
 ```js
-elements = {
   // if $root is "App", "App_title" DOM element will be returned
-  $title: this.find("title"),
-}
-// use it...
-console.log(elements.$title)
+$title =  this.find("title")
 ```
 
 With typescript:
 
 ```ts
-elements = {
-  $title: this.find<HTMLElement>("title"),
-  $foo: this.find<HTMLElement[]>("foo"),
-}
+$title = this.find<HTMLElement>("title")
+$foo = this.find<HTMLElement[]>("foo")
 ```
 
 As `add()` method, if a list of element is exist in DOM, `find()` will returns a list of HTMLElement.
 It's possible to force an array return via `returnArray` params.
-
-### `elements`
-
-this property is a simple list of BEM elements of current component.
 
 ## `Stack` extented class
 
@@ -340,11 +294,7 @@ Each pages can declare it's own page transition `playIn` & `playOut`.
 ```js
 class HomePage extends Component {
   static attrName = "HomePage"
-  constructor(...rest) {
-    super(...rest)
-    this.init()
-  }
-
+  
   // Prepare playIn and playOut page transitions used by Stack (example with gsap)
   playIn(comeFrom, resolve) {
     gsap.from(this.$root, { autoAlpha: 0, onComplete: ()=> resolve() })

--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ import { Component } from "@wbe/compose"
 import Header from "Header"
 
 class App extends Component {
-  // set the same value than `data-component` attribute value
+  // same value than `data-component` attribute
   static attrName = "App"
-  
 }
 ```
 
@@ -96,7 +95,7 @@ Method called when any **children** component in DOM subtree changed.
 
 ## Methods & Properties
 
-### `attrName`
+### attrName
 
 static `string`
 
@@ -115,7 +114,9 @@ class Foo extends Component {
 }
 ```
 
-### `add()`
+### add
+
+`add()`
 
 This method allows to 'add', 'create' new Component instance to the tree.
 It returns instance(s) and associated properties.
@@ -129,10 +130,10 @@ add<T = Component, P = TProps>(
 ): T;
 ```
 
-Add component in class core: 
+Add component in class core:
 
 ```js
-bar = this.add(Bar);
+bar = this.add(Bar)
 
 // then, access child Bar instance
 this.bar.$root
@@ -153,7 +154,7 @@ In case, multi children of the same component is found, `add()` will returned an
 ```
 
 ```js
-bar = this.add(Bar); // will returned array of bar instances
+bar = this.add(Bar) // will returned array of bar instances
 ```
 
 If we don't know how many instance of our component `Bar` exist,
@@ -181,18 +182,15 @@ With typescript, we can type the `props` object:
 bar = this.add<Bar, { myProp: string }>(Bar, { myProp: "foo" }, false)
 ```
 
-### `components()`
+### find
 
-As used on `add()` method, `components` allows to retrieve a list on children component instances create by `add()`.
-When current component instance is unmounted, all instances returned by `components` method, will be automatically unmounted.
-
-### `find()`
+`find()`
 
 This method allows to retrieve B.E.M. element of current $root component.
 
 ```js
-  // if $root is "App", "App_title" DOM element will be returned
-$title =  this.find("title")
+// if $root is "App", "App_title" DOM element will be returned
+$title = this.find("title")
 ```
 
 With typescript:
@@ -205,7 +203,7 @@ $foo = this.find<HTMLElement[]>("foo")
 As `add()` method, if a list of element is exist in DOM, `find()` will returns a list of HTMLElement.
 It's possible to force an array return via `returnArray` params.
 
-## `Stack` extented class
+## Stack
 
 In order to get dynamic page fetching and refreshing without reload,
 `Stack` extended class is a middleware class between our App root component and `Component` extended class.
@@ -255,7 +253,9 @@ class App extends Stack {
 }
 ```
 
-### `pageTransitions()`
+### pageTransitions
+
+`pageTransitions()`
 
 It's possible to define custom transition senario with `pageTransitions`:
 
@@ -275,9 +275,9 @@ class App extends Stack {
 }
 ```
 
-### Page `playIn()` & `playOut()`
+### Page playIn & playOut
 
-Each pages can declare it's own page transition `playIn` & `playOut`.
+Each pages can declare it's own page transition `playIn()` & `playOut()`.
 
 `HomePage.js`
 (same for AboutPage)
@@ -285,31 +285,31 @@ Each pages can declare it's own page transition `playIn` & `playOut`.
 ```js
 class HomePage extends Component {
   static attrName = "HomePage"
-  
+
   // Prepare playIn and playOut page transitions used by Stack (example with gsap)
   playIn(comeFrom, resolve) {
-    gsap.from(this.$root, { autoAlpha: 0, onComplete: ()=> resolve() })
+    gsap.from(this.$root, { autoAlpha: 0, onComplete: () => resolve() })
   }
   playOut(goTo, resolve) {
-    gsap.to(this.$root, { autoAlpha: 0, onComplete: ()=> resolve() })
+    gsap.to(this.$root, { autoAlpha: 0, onComplete: () => resolve() })
   }
 }
 ```
 
 ## Options
 
-- `forcePageReload` {boolean} *default: false*
-Force all pages to reload instead of the dynamic new document fetching process.
+- `forcePageReload` {boolean} _default: false_
+  Force all pages to reload instead of the dynamic new document fetching process.
 
-- `forcePageReloadIfDocumentIsFetching` {boolean} *default: false*
-Force page to reload only if document is fetching.
-  
-- `disableLinksDuringTransitions` {boolean} *default: false*
-disable links during transition.
+- `forcePageReloadIfDocumentIsFetching` {boolean} _default: false_
+  Force page to reload only if document is fetching.
 
-- `disableHistoryDuringTransitions` {boolean} *default: false*
-disable history during transition allow to block transition on popstate event too.
-  
+- `disableLinksDuringTransitions` {boolean} _default: false_
+  disable links during transition.
+
+- `disableHistoryDuringTransitions` {boolean} _default: false_
+  disable history during transition allow to block transition on popstate event too.
+
 ```js
 class App extends Stack {
   // ...
@@ -317,7 +317,6 @@ class App extends Stack {
   forcePageReload = false
   disableLinksDuringTransitions = false
   disableHistoryDuringTransitions = false
-  
 }
 ```
 
@@ -330,12 +329,10 @@ To get some additional logs, add this line on your browser console:
 localStorage.debug = "compose:*"
 ```
 
-## Credits 
+## Credits
 
 © [Willy Brauner](https://willybrauner.com)
 
 ## Licence
 
 MIT
-
-

--- a/example/about.html
+++ b/example/about.html
@@ -33,6 +33,7 @@
             </header>
           </div>
         </div>
+        <footer class="App_footer Footer" data-component="Footer">footer</footer>
       </main>
     </div>
 

--- a/example/index.html
+++ b/example/index.html
@@ -25,12 +25,6 @@
                 I'm a button
               </button>
             </header>
-            <button class="MainButton MainButton-2" data-component="MainButton">
-              I'm a button
-            </button>
-            <button class="MainButton MainButton-3" data-component="MainButton">
-              I'm a button
-            </button>
           </div>
         </div>
       </main>

--- a/example/index.html
+++ b/example/index.html
@@ -27,6 +27,7 @@
             </header>
           </div>
         </div>
+        <footer class="App_footer Footer" data-component="Footer">footer</footer>
       </main>
     </div>
 

--- a/example/src/components/App.ts
+++ b/example/src/components/App.ts
@@ -3,6 +3,7 @@ import HomePage from "../pages/HomePage"
 import AboutPage from "../pages/AboutPage"
 import WorkPage from "../pages/WorkPage"
 import debug from "@wbe/debug"
+import Footer from "./Footer"
 const log = debug(`front:App`)
 
 type TProps = {
@@ -15,10 +16,7 @@ type TProps = {
 export default class App extends Stack<TProps> {
   public static attrName = "App"
 
-  // constructor($root, props: TProps) {
-  //   super($root, props)
-  // }
-
+  
   public addPages() {
     return {
       HomePage,
@@ -26,12 +24,11 @@ export default class App extends Stack<TProps> {
       WorkPage,
     }
   }
-
-  /**
-   * mounted
-   */
+  
+  footer = this.add(Footer)
+  
   public mounted() {
-    
+    log("this", this.footer);
   }
 
   protected async pageTransitions(

--- a/example/src/components/App.ts
+++ b/example/src/components/App.ts
@@ -15,9 +15,9 @@ type TProps = {
 export default class App extends Stack<TProps> {
   public static attrName = "App"
 
-  constructor($root, props: TProps) {
-    super($root, props)
-  }
+  // constructor($root, props: TProps) {
+  //   super($root, props)
+  // }
 
   public addPages() {
     return {

--- a/example/src/components/Footer.ts
+++ b/example/src/components/Footer.ts
@@ -1,0 +1,21 @@
+import { Component } from "../../../src";
+import debug from "@wbe/debug"
+const log = debug(`front:Footer`)
+
+type TProps = {}
+
+/**
+ * @name Footer
+ */
+export default class Footer extends Component<TProps> {
+  public static attrName = "Footer";
+  mounted () {
+    log('Footer is mounted')
+  }
+  unmounted () {}
+
+  logMe()
+  {
+    log("Log Me!", this)
+  }
+}

--- a/example/src/components/Header.ts
+++ b/example/src/components/Header.ts
@@ -15,14 +15,7 @@ type TAddComponents = {
 export default class Header extends Component<TStaticProps, TAddComponents> {
   public static attrName = "Header"
 
-  constructor($root, props) {
-    super($root, props)
-    this.init()
-  }
-
-  public addComponents = () => ({
-    MainButton: this.add<MainButton[]>(MainButton),
-  })
+  protected MainButton = this.add<MainButton[]>(MainButton)
 
   public mounted() {
     log("mounted")

--- a/example/src/components/Header.ts
+++ b/example/src/components/Header.ts
@@ -5,20 +5,15 @@ const log = debug(`front:Header`)
 
 type TStaticProps = {}
 
-type TAddComponents = {
-  MainButton: InstanceType<typeof MainButton>[]
-}
-
 /**
  * @name Header
  */
-export default class Header extends Component<TStaticProps, TAddComponents> {
+export default class Header extends Component<TStaticProps> {
   public static attrName = "Header"
 
-  protected MainButton = this.add<MainButton[]>(MainButton)
+  public MainButton = this.add<MainButton[]>(MainButton)
 
   public mounted() {
-    log("mounted")
     window.addEventListener("resize", this.resizeHandler)
   }
 

--- a/example/src/components/MainButton.ts
+++ b/example/src/components/MainButton.ts
@@ -7,4 +7,7 @@ const log = debug(`front:MainButton`)
  */
 export default class MainButton extends Component {
   public static attrName = "MainButton";
+
+  mounted () { }
+  
 }

--- a/example/src/components/MainButton.ts
+++ b/example/src/components/MainButton.ts
@@ -7,9 +7,4 @@ const log = debug(`front:MainButton`)
  */
 export default class MainButton extends Component {
   public static attrName = "MainButton";
-
-  constructor($root, props) {
-    super($root, props);
-    this.init();
-  }
 }

--- a/example/src/pages/AboutPage.ts
+++ b/example/src/pages/AboutPage.ts
@@ -16,14 +16,7 @@ type TAddComponents = {
 export default class AboutPage extends Component<TStaticProps, TAddComponents> {
   public static attrName = "AboutPage"
 
-  constructor($root, props) {
-    super($root, props)
-    this.init()
-  }
-
-  public addComponents = () => ({
-    Header: this.add(Header),
-  })
+  protected Header = this.add(Header)
 
   public mounted() {
     log("> mounted")

--- a/example/src/pages/AboutPage.ts
+++ b/example/src/pages/AboutPage.ts
@@ -6,24 +6,20 @@ const log = debug(`front:AboutPage`)
 
 type TStaticProps = {}
 
-type TAddComponents = {
-  Header: InstanceType<typeof Header>
-}
-
 /**
  * @name AboutPage
  */
-export default class AboutPage extends Component<TStaticProps, TAddComponents> {
+export default class AboutPage extends Component<TStaticProps> {
   public static attrName = "AboutPage"
 
-  protected Header = this.add(Header)
+  protected header = this.add(Header)
 
-  public mounted() {
+  mounted() {
     log("> mounted")
     window.addEventListener("resize", this.resizeHandler)
   }
 
-  public unmounted() {
+  unmounted() {
     log("> unmounted")
     window.removeEventListener("resize", this.resizeHandler)
   }

--- a/example/src/pages/HomePage.ts
+++ b/example/src/pages/HomePage.ts
@@ -18,6 +18,7 @@ export default class HomePage extends Component<TStaticProps> {
 
   public mounted() {
     log('> mounted')
+
     window.addEventListener("resize", this.resizeHandler)
   }
 

--- a/example/src/pages/HomePage.ts
+++ b/example/src/pages/HomePage.ts
@@ -18,18 +18,9 @@ type TAddComponents = {
 export default class HomePage extends Component<TStaticProps, TAddComponents> {
   public static attrName = "HomePage"
 
-  constructor($root, props) {
-    super($root, props)
-    this.init()
-  }
-
-  public addComponents = () => ({
-      Header: this.add(Header),
-      MainButton: this.add<MainButton>(MainButton),
-  })
+  protected Header = this.add(Header)
 
   public mounted() {
-    log("this.components", this.components)
     log('> mounted')
     window.addEventListener("resize", this.resizeHandler)
   }

--- a/example/src/pages/HomePage.ts
+++ b/example/src/pages/HomePage.ts
@@ -7,15 +7,11 @@ const log = debug(`front:HomePage`)
 
 type TStaticProps = {}
 
-type TAddComponents = {
-  Header: InstanceType<typeof Header>
-  MainButton: InstanceType<typeof MainButton>
-}
 
 /**
  * @name HomePage
  */
-export default class HomePage extends Component<TStaticProps, TAddComponents> {
+export default class HomePage extends Component<TStaticProps> {
   public static attrName = "HomePage"
 
   protected Header = this.add(Header)

--- a/example/src/pages/WorkPage.ts
+++ b/example/src/pages/WorkPage.ts
@@ -6,14 +6,10 @@ const log = debug(`front:WorkPage`)
 
 type TStaticProps = {}
 
-type TAddComponents = {
-  Header: InstanceType<typeof Header>
-}
-
 /**
  * @name WorkPage
  */
-export default class WorkPage extends Component<TStaticProps, TAddComponents> {
+export default class WorkPage extends Component<TStaticProps> {
   public static attrName = "WorkPage"
 
   protected Header = this.add(Header)

--- a/example/src/pages/WorkPage.ts
+++ b/example/src/pages/WorkPage.ts
@@ -16,19 +16,9 @@ type TAddComponents = {
 export default class WorkPage extends Component<TStaticProps, TAddComponents> {
   public static attrName = "WorkPage"
 
-  constructor($root, props) {
-    super($root, props)
-    this.init()
-  }
-  
-  public addComponents() {
-    return {
-      Header: this.add(Header),
-    }
-  }
+  protected Header = this.add(Header)
 
   public mounted() {
-    log("use this.components", this.components)
     window.addEventListener("resize", this.resizeHandler)
   }
 

--- a/example/work.html
+++ b/example/work.html
@@ -30,6 +30,7 @@
             </header>
           </div>
         </div>
+        <footer class="App_footer Footer" data-component="Footer">footer</footer>
       </main>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wbe/compose",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wbe/compose",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@wbe/debug": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wbe/compose",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Compose is a tiny zero dependency library for vanilla javascript component approach and page transitions management.",
   "author": "Willy Brauner",
   "license": "MIT",

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -28,18 +28,15 @@ export class Component<Props = TProps> {
    */
   public name: string
 
-
   /**
    * Root DOM element
    */
   public $root: HTMLElement
 
-
   /**
    * Static props from the parent component
    */
   public props: Props
-
   
   /**
    * Random ID of current instance
@@ -236,7 +233,7 @@ export class Component<Props = TProps> {
   private getDomElement($root: HTMLElement, name: string): HTMLElement[] {
     return [
       // @ts-ignore
-      ...($root?.querySelectorAll(`*[${Component.componentAttr}=${name}]`) || []),
+      ...($root?.querySelectorAll(`*[${COMPONENT_ATTR}=${name}]`) || []),
     ]
   }
 

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -25,12 +25,6 @@ export class Component<Props = TProps, TAddComponents = any> {
   public $root: HTMLElement
   public props: Props
 
-  // register children components
-  public addComponents(): TAddComponents {
-    return {} as TAddComponents
-  }
-  public components: TAddComponents
-
   public elements: TElements
   public id: number
   public isMounted: boolean
@@ -52,6 +46,7 @@ export class Component<Props = TProps, TAddComponents = any> {
     this.$root.setAttribute(Component.idAttr, `${COMPONENT_ID}`)
     this.id = COMPONENT_ID
     COMPONENT_ID++
+    window.setTimeout(() => this.init(), 0)
   }
 
   /**
@@ -78,7 +73,6 @@ export class Component<Props = TProps, TAddComponents = any> {
   private _mounted(): void {
     log(this.name, "mounted")
     // instanciate children components just before mounted
-    this.components = this.addComponents()
     this.mounted()
     this.isMounted = true
   }
@@ -91,10 +85,9 @@ export class Component<Props = TProps, TAddComponents = any> {
   private _unmounted(): void {
     this.unmounted()
     this.isMounted = false
-
     this.onChildrenComponents((component: Component) => {
       COMPONENT_ID--
-      component?._unmounted?.()
+      component?._unmounted()
     })
     log(this.name, "unmounted")
   }
@@ -223,16 +216,25 @@ export class Component<Props = TProps, TAddComponents = any> {
   }
 
   /**
-   * Process callback function on each children component
+   * Process callback function on each children components
    * @param callback
    * @protected
    */
   private onChildrenComponents(callback: (component) => void): void {
-    this.components &&
-      Object.keys(this.components).forEach((component) => {
-        const child = this.components?.[component]
-        Array.isArray(child) ? child?.forEach((c) => callback(c)) : callback(child)
-      })
+    Object.keys(this)?.forEach((child) => {
+      const curr = this?.[child]
+      if (Array.isArray(curr) )
+      {
+        curr.forEach(c => {
+          if (c instanceof Component) {
+            callback(c)
+         }
+        })
+      }
+      else if (curr instanceof Component) {
+         callback(curr)
+      }
+    })
   }
 
   /**

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -15,6 +15,8 @@ export type TTransition = {
  * Glob scope
  */
 let COMPONENT_ID = 0
+export const COMPONENT_ATTR = "data-component"
+export const ID_ATTR = "data-component-id"
 
 /**
  * Component class 
@@ -55,14 +57,6 @@ export class Component<Props = TProps> {
    */
   private observer: MutationObserver
   
-
-  /**
-   * Attributes used for DOM
-   * ex: data-component="HomePage" data-component-id="1"
-   */
-  public static componentAttr: string = "data-component"
-  public static idAttr: string = "data-component-id"
-
   /**
    * @param $root Dom element link with the instance
    * @param props Object properties of the instance
@@ -78,7 +72,7 @@ export class Component<Props = TProps> {
     this.name = attrName || this.getComponentName(this.$root)
 
     // set ID on DOM element
-    this.$root.setAttribute(Component.idAttr, `${COMPONENT_ID}`)
+    this.$root.setAttribute(ID_ATTR, `${COMPONENT_ID}`)
     this.id = COMPONENT_ID
     COMPONENT_ID++
 
@@ -127,11 +121,6 @@ export class Component<Props = TProps> {
     })
     log(this.name, "UNmounted")
   }
-
-  /**
-   * Callback of watch method execute each time children DOM nodes changed
-   */
-  public updated(mutation: MutationRecord): void {}
 
   /**
    * Add is a register child component function
@@ -279,7 +268,7 @@ export class Component<Props = TProps> {
    * @param $node
    */
   private getComponentName($node: HTMLElement = this.$root): string {
-    return $node?.getAttribute?.(Component.componentAttr)
+    return $node?.getAttribute?.(COMPONENT_ATTR)
   }
 
   /**
@@ -287,7 +276,7 @@ export class Component<Props = TProps> {
    * @param $node
    */
   private getComponentId($node: HTMLElement): number {
-    return $node?.getAttribute?.(Component.idAttr) && parseInt($node.getAttribute(Component.idAttr))
+    return $node?.getAttribute?.(ID_ATTR) && parseInt($node.getAttribute(ID_ATTR))
   }
 
   /**
@@ -322,8 +311,6 @@ export class Component<Props = TProps> {
             }
           })
         }
-
-        this.updated(mutation)
       }
     }
 

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -5,7 +5,6 @@ const log = debug(`compose:Component`)
 export type TProps = { [x: string]: any } | void
 export type TFlatArray<T> = T extends any[] ? T[number] : T
 export type TNewComponent<C, P> = new <P = TProps>(...rest: any[]) => TFlatArray<C>
-export type TElements = { [x: string]: HTMLElement | HTMLElement[] }
 export type TTransition = {
   comeFrom?: string
   goTo?: string
@@ -18,17 +17,49 @@ export type TTransition = {
 let COMPONENT_ID = 0
 
 /**
- * Component
+ * Component class 
  */
-export class Component<Props = TProps, TAddComponents = any> {
+export class Component<Props = TProps> {
+
+  /**
+   * Component name
+   */
   public name: string
+
+
+  /**
+   * Root DOM element
+   */
   public $root: HTMLElement
+
+
+  /**
+   * Static props from the parent component
+   */
   public props: Props
 
-  public elements: TElements
+  
+  /**
+   * Random ID of current instance
+   * Counter is incremented on each instance and add as attribute on DOM element 
+   */
   public id: number
-  public isMounted: boolean
+
+  /**
+   * Flag to know if current instance is mounted 
+   */
+  private isMounted: boolean
+
+  /**
+   * Mutation observer allows to know if current DOM element change
+   */
   private observer: MutationObserver
+  
+
+  /**
+   * Attributes used for DOM
+   * ex: data-component="HomePage" data-component-id="1"
+   */
   public static componentAttr: string = "data-component"
   public static idAttr: string = "data-component-id"
 
@@ -38,6 +69,10 @@ export class Component<Props = TProps, TAddComponents = any> {
    * @param attrName is value from data-component="{name}"
    */
   constructor($root?: HTMLElement, props?: Props, attrName?: string) {
+    // Before mount method executed on construct root, before all process
+    this._beforeMount()
+
+    // keep params in local
     this.props = props
     this.$root = $root
     this.name = attrName || this.getComponentName(this.$root)
@@ -46,14 +81,15 @@ export class Component<Props = TProps, TAddComponents = any> {
     this.$root.setAttribute(Component.idAttr, `${COMPONENT_ID}`)
     this.id = COMPONENT_ID
     COMPONENT_ID++
+
+    // hack: exe init method with timeout to access `this` inside component methods
     window.setTimeout(() => this.init(), 0)
   }
 
   /**
-   * Init to call in contructor (to keep context)
+   * Init 
    */
-  protected init() {
-    this._beforeMount()
+  private init() {
     this._mounted()
     this._watchChildren()
   }
@@ -89,7 +125,7 @@ export class Component<Props = TProps, TAddComponents = any> {
       COMPONENT_ID--
       component?._unmounted()
     })
-    log(this.name, "unmounted")
+    log(this.name, "UNmounted")
   }
 
   /**

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -126,8 +126,8 @@ export class Component<Props = TProps> {
   protected add<T = any, P = TProps>(
     classComponent: TNewComponent<T, P>,
     props?: P,
-    attrName?: string,
-    returnArray: boolean = false
+    returnArray?: boolean,
+    attrName?: string
   ): T {
     // prepare instances array
     const localInstances = []

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -89,7 +89,7 @@ export class Component<Props = TProps> {
   /**
    * Init 
    */
-  private init() {
+  protected init() {
     this._mounted()
     this._watchChildren()
   }

--- a/src/Stack.ts
+++ b/src/Stack.ts
@@ -29,6 +29,9 @@ type TCache = {
 }
 
 const PARSER = new DOMParser()
+const PAGE_CONTAINER_ATTR = "data-page-transition-container"
+const PAGE_WRAPPER_ATTR = "data-page-transition-wrapper"
+const PAGE_URL_ATTR = "data-page-transition-url"
 
 /**
  * Stack
@@ -37,48 +40,94 @@ const PARSER = new DOMParser()
  * and `Component` extended class.
  */
 export class Stack<Props = TProps> extends Component {
-  // DOM attributes
-  public static pageContainerAttr = "data-page-transition-container"
-  public static pageWrapperAttr = "data-page-transition-wrapper"
-  public static pageUrlAttr = "data-page-transition-url"
-
-  // reload if document is fetching
+  /**
+   * reload if document is fetching
+   */
   public forcePageReloadIfDocumentIsFetching: boolean = false
-  // force all pages to reload instead the dynamic new document fetching process
+  
+  /**
+   * force all pages to reload instead the dynamic new document fetching process
+   */
   public forcePageReload: boolean = false
-  // disable links during transition
+  
+  /**
+   * disable links during transition
+   */
   public disableLinksDuringTransitions: boolean = false
+
+  /**
+   * disable history during transition
+   */
   public disableHistoryDuringTransitions: boolean = false
 
-  // Register pages from parent class
+  /**
+   * Register pages from parent class
+   * @returns 
+   */
   public addPages(): TPages {
     return
   }
   private pages: TPages
 
-  // the current URL to request
+  /**
+   *  the current URL to request
+   */
   protected currentUrl: string = null
-  protected currentPage: IPage
-  protected prevPage: IPage
-  protected isFirstPage = true
 
-  // page container
+  /**
+   * current page {IPage}
+   */
+  protected currentPage: IPage
+
+  /**
+   * previous page {IPage}
+   */
+  protected prevPage: IPage
+
+  /**
+   * is first page state 
+   */
+  protected isFirstPage: boolean = true
+
+  /**
+   * page container DOM element 
+   */
   protected $pageContainer: HTMLElement
+
+  /**
+   * page wrapper DOM element
+   */
   protected $pageWrapper: HTMLElement
 
-  // promise ref used in playIn and playOut medthods to keep reject promise
+  /**
+   * promise ref used in playIn and playOut medthods to keep reject promise
+   */
   protected playInPromiseRef: TPromiseRef = { reject: undefined }
   protected playOutPromiseRef: TPromiseRef = { reject: undefined }
 
-  // check if new page document html is in fetching step
+  /**
+   * check if new page document html is in fetching step
+   */
   private _fetching: boolean = false
-  // check if page is in animate process
+  
+  /**
+   * check if page is in animate process
+   */
   private _pageIsAnimating: boolean = false
-  // cache
+
+  /**
+   * Page requested cache
+   * this cache contains all visited/ requested pages information
+   * used instead of re-fetch new Document 
+   */
   private _cache: { [url: string]: TCache }
 
+  /**
+   * Construct
+   * @param $root  
+   * @param props 
+   */
   constructor($root: HTMLElement, props: Props) {
-    // relay
     super($root, props)
 
     // init
@@ -176,7 +225,7 @@ export class Stack<Props = TProps> extends Component {
   private handleLinks = (event): void => {
     if (!event) return
     // get page url attr
-    const url = event?.currentTarget?.getAttribute(Stack.pageUrlAttr)
+    const url = event?.currentTarget?.getAttribute(PAGE_URL_ATTR)
     // if disable transtiions is active, open new page
     if (this.forcePageReload) {
       window.open(url, "_self")
@@ -429,7 +478,7 @@ export class Stack<Props = TProps> extends Component {
    * @private
    */
   private getPageContainer(): HTMLElement {
-    return document.body.querySelector(`*[${Stack.pageContainerAttr}]`)
+    return document.body.querySelector(`*[${PAGE_CONTAINER_ATTR}]`)
   }
 
   /**
@@ -438,7 +487,7 @@ export class Stack<Props = TProps> extends Component {
    * @private
    */
   private getPageWrapper($node: HTMLElement): HTMLElement {
-    return $node.querySelector(`*[${Stack.pageWrapperAttr}]`)
+    return $node.querySelector(`*[${PAGE_WRAPPER_ATTR}]`)
   }
 
   /**
@@ -528,7 +577,7 @@ export class Stack<Props = TProps> extends Component {
   private getLinksWithAttr(): HTMLElement[] {
     return [
       // @ts-ignore
-      ...this.$pageContainer?.querySelectorAll(`*[${Stack.pageUrlAttr}]`),
+      ...this.$pageContainer?.querySelectorAll(`*[${PAGE_URL_ATTR}]`),
     ]
   }
 

--- a/src/Stack.ts
+++ b/src/Stack.ts
@@ -1,4 +1,4 @@
-import { Component } from "./Component"
+import { Component, COMPONENT_ATTR } from "./Component"
 import type { TProps } from "./Component"
 import debug from "@wbe/debug"
 const log = debug("compose:Stack")
@@ -461,7 +461,7 @@ export class Stack<Props = TProps> extends Component {
    */
   private getPageName($pageRoot: HTMLElement): string {
     for (const page of Object.keys(this.pages)) {
-      if (page == $pageRoot.getAttribute(Component.componentAttr)) return page
+      if (page == $pageRoot.getAttribute(COMPONENT_ATTR)) return page
     }
   }
 

--- a/src/Stack.ts
+++ b/src/Stack.ts
@@ -331,6 +331,7 @@ export class Stack<Props = TProps> extends Component {
     if (cache) {
       log("Use cache", cache)
       const { title, $pageRoot, pageName, instance, playIn } = cache
+      instance.beforeMount()
       instance.init()
       this.addPageInDOM($pageRoot)
       this.updateMetas(title)

--- a/src/Stack.ts
+++ b/src/Stack.ts
@@ -91,10 +91,6 @@ export class Stack<Props = TProps> extends Component {
     // start patch history
     this.patchHistoryStates()
 
-    // init method from extended Component class
-    // IMPORTANT to init Component lifecicle after addding setting this.pages property
-    this.init()
-
     // start page events
     this.start()
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@ export { Stack } from "./Stack"
 export { Component } from "./Component"
 
 export type { IPage, TPages } from "./Stack"
-export type { TTransition, TElements, TNewComponent } from "./Component"
+export type { TTransition, TNewComponent } from "./Component"


### PR DESCRIPTION
- [x] remove constructor in component declaration. `init()` method is automatically called in Component constructor.
- [x] remove `this.components`

Add child/children components :
````js
  public header = this.add(Header)
````
- [x] remove `this.elements` properties 
- [x] change `add()` method params order 
```ts
add<T = Component, P = TProps>(
    classComponent: TAddComponent,
    props?: P,
    returnArray?: boolean,
    attrName?: string
): T;
```

- [x] Remove `updated()` method


